### PR TITLE
Draft planner fixes

### DIFF
--- a/draft_planner/static/scripts/draftplanner.js
+++ b/draft_planner/static/scripts/draftplanner.js
@@ -138,9 +138,10 @@ function appendPokemon(item,gen){
 }
 
 function classify(prefix,suffix){
-    let newsuffix=suffix.toLowerCase()
-    return prefix+"-"+suffix.replace(/ /g,"").replace(/:/g,"").replace(/%/g,"").replace(".","").toLowerCase()
+    let newsuffix = suffix.toLowerCase()
+    return prefix + "-" + suffix.replace(/ /g,"").replace(/:/g,"").replace(/%/g,"").replace(".","").replace("'","").toLowerCase()
 }
+
 function add_filter(filter){
     var filtertext, filterid
     clickedtext=filter.text()

--- a/draft_planner/templates/draft_planner.html
+++ b/draft_planner/templates/draft_planner.html
@@ -350,7 +350,7 @@
                 </tr>
                 <tr>
                     <td class="teamdata type-electric"></td>
-                    <td class="teamdata type-dark"></td>
+                    <td class="teamdata type-ground"></td>
                     <td class="teamdata type-poison"></td>
                 </tr>
                 <tr>


### PR DESCRIPTION
I fixed a couple of bugs within the draft planner page.

There was a bug adding the Tapus, Aegislash or any pokemon that has moves that contain single quotes, like King's Shield or Nature's Madness for example.

The ground type on the "cores" table wasn't being displayed correctly.